### PR TITLE
Alias errors for easier creation in scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,5 +11,7 @@ module.exports = {
   MockScriptStore: MockScriptStore,
   Util: Util,
   Error: FXOError,
+  AuthError: FXOError.AuthError,
+  ServiceError: FXOError.ServiceError,
   Chai: Chai
 };

--- a/lib/scriptRunner.js
+++ b/lib/scriptRunner.js
@@ -22,10 +22,11 @@ var ScriptRunner = function(service,options){
  * @return {[type]}         [description]
  */
 ScriptRunner.prototype.run = function(method,script,options){
-
 	if(arguments.length === 3){
 		options = arguments[1];
 	}
+
+	options = options || {};
 
 	// If there is no incoming authentication, use ours
 	if(!options.credentials){

--- a/lib/service.js
+++ b/lib/service.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var Poller = require('./poller');
 var _ = require('lodash');
+var winston = require('winston');
 
 /**
  * FlowXO SDK Service
@@ -65,7 +66,17 @@ Service.prototype.requireMethods = function(dir){
   }
 };
 
+var ensureOptions = function(options) {
+  return _.defaults(options || {}, {
+    logger: new (winston.Logger)(),
+    input: {},
+    credentials: {}
+  });
+};
+
 Service.prototype.runMethodScript = function(method,script,options,cb){
+  options = ensureOptions(options);
+
   // Check we have the method...
   if(!(this.methodsIndexed && this.methodsIndexed[method])){
     return cb(new Error('ServiceError: Service ' + this.name + ' does not define method ' + method));
@@ -90,6 +101,8 @@ Service.prototype.runMethodScript = function(method,script,options,cb){
 };
 
 Service.prototype.runServiceScript = function(script,options,cb){
+  options = ensureOptions(options);
+
   // Check we have this service script
   if(!this.scripts.hasOwnProperty(script)){
     return cb(new Error('ServiceError: Service ' + this.name + ' does not define script "' + script +'"'));


### PR DESCRIPTION
So now we can do `new sdk.ServiceError()` instead of `new sdk.Error.ServiceError()`