### PR TITLE
Output improvements

### DIFF
--- a/tasks/lib/run.js
+++ b/tasks/lib/run.js
@@ -3,13 +3,13 @@
 require('./check-deps');
 
 var util = require('util'),
-    path = require('path'),
-    inquirer = require('inquirer'),
-    chalk = require('chalk'),
-    async = require('async'),
-    chai = require('chai'),
-    FxoUtils = require('flowxo-utils'),
-    SDK = require('../../index.js');
+  path = require('path'),
+  inquirer = require('inquirer'),
+  chalk = require('chalk'),
+  async = require('async'),
+  chai = require('chai'),
+  FxoUtils = require('flowxo-utils'),
+  SDK = require('../../index.js');
 
 chai.use(SDK.Chai);
 
@@ -22,36 +22,75 @@ RunUtil.displayScriptData = function(grunt, data) {
   grunt.log.writeln(chalk.cyan(JSON.stringify(data, null, 2)));
 };
 
+/**
+ * Processes the data returned from a script
+ * into a format suitable for outputing
+ * @param  {Array} outputs Flow XO Output Field objects
+ * @param  {Object} data Data returned from script
+ * @return {Array} Processed data - either an array of fields, or an
+ * array of arrays if the incoming data
+ */
+RunUtil.formatScriptOutput = function(outputs, data) {
+
+  // Flatten the output.
+  var flattened = FxoUtils.getFlattenedFields(data);
+
+  var flattenedIdx = flattened.reduce(function(result, field) {
+    result[field.key] = field;
+    return result;
+  }, {});
+
+  return outputs.reduce(function(result, output) {
+    // Lookup the field from the data
+    var field = flattenedIdx[output.key];
+    result.push({
+      label: output.label,
+      value: field ? data[field.key] : undefined
+    });
+    return result;
+  }, []);
+};
+
 RunUtil.displayScriptOutput = function(grunt, outputs, data) {
+
+  var fieldIndent = '  ';
+  var objIndent = '';
+  var dataLabelled;
+
+  function writeField(field, last) {
+    grunt.log.writeln(chalk.cyan(fieldIndent + JSON.stringify(field.label) + ': ' + JSON.stringify(field.value) + '' + (last ? '' : ',')));
+  }
+
+  function writeObject(obj, last) {
+    grunt.log.writeln(chalk.cyan(objIndent + '{'));
+    for(var i = 0; i < obj.length; i++) {
+      writeField(obj[i], i === obj.length - 1);
+    }
+    grunt.log.writeln(chalk.cyan(objIndent + '}' + (last ? '' : ',')));
+  }
+
   if(outputs.length) {
-    // First create an indexed hash of fields
-    var fieldsIdx = outputs.reduce(function(data, f) {
-      data[f.key] = f;
-      return data;
-    }, {});
-
-    var labelise = function(data) {
-      // Flatten the output.
-      var flattened = FxoUtils.getFlattenedFields(data);
-
-      // Create a new object, with the key as the label from
-      // the output. If there is no output field corresponding
-      // to the data, ignore it.
-      return flattened.reduce(function(result, data) {
-        var field = fieldsIdx[data.key];
-        if(field) {
-          result[field.label] = data.value;
-        }
-        return result;
-      }, {});
-    };
-
-    var dataLabelled = util.isArray(data) ?
-      data.map(labelise) :
-      labelise(data);
 
     CommonUtil.header(grunt, 'LABELLED:', 'green');
-      grunt.log.writeln(chalk.cyan(JSON.stringify(dataLabelled, null, 2)));
+
+    // If this is an array
+    if(util.isArray(data)) {
+      // Set the indents
+      fieldIndent = '    ';
+      objIndent = '  ';
+
+      grunt.log.writeln(chalk.cyan('['));
+
+      for(var i = 0; i < data.length; i++) {
+        dataLabelled = RunUtil.formatScriptOutput(outputs, data[i]);
+        writeObject(dataLabelled, i === data.length - 1);
+      }
+
+      grunt.log.writeln(chalk.cyan(']'));
+    } else {
+      dataLabelled = RunUtil.formatScriptOutput(outputs, data);
+      writeObject(dataLabelled, true);
+    }
   }
 };
 
@@ -108,20 +147,20 @@ RunUtil.getCredentials = function(grunt, credentialsPath) {
 };
 
 RunUtil.getRunFile = function(grunt) {
-  return (grunt.option('name') || 'runs') + '.json';
+  return(grunt.option('name') || 'runs') + '.json';
 };
 
 RunUtil.run = function(grunt, options, cb) {
   var runner = options.runner,
-      service = options.service,
-      method = options.method;
+    service = options.service,
+    method = options.method;
 
   // Firstly, validate the service.
   // If it is not configured correctly, end.
   RunUtil.validateService(grunt, service);
 
   var inputs = options.inputs || [],
-      outputs = [];
+    outputs = [];
 
   var inputsPredefined = inputs.length !== 0;
 
@@ -324,8 +363,8 @@ RunUtil.runUntilStopped = function(grunt, options, cb) {
 
 RunUtil.runSingleScript = function(grunt, options, cb) {
   var runner = options.runner,
-      service = options.service,
-      method, script;
+    service = options.service,
+    method, script;
 
   // Firstly, validate the service.
   // If it is not configured correctly, end.
@@ -390,8 +429,8 @@ RunUtil.runSingleScript = function(grunt, options, cb) {
 
 RunUtil.runRecorded = function(grunt, options, cb) {
   var runFile = path.join(
-        options.runsFolder,
-        RunUtil.getRunFile(grunt));
+    options.runsFolder,
+    RunUtil.getRunFile(grunt));
 
   var tests;
   try {
@@ -418,10 +457,10 @@ RunUtil.runRecorded = function(grunt, options, cb) {
 
 RunUtil.runReplayed = function(grunt, options, cb) {
   var runner = options.runner,
-      service = options.service,
-      runFile = path.join(
-        options.runsFolder,
-        RunUtil.getRunFile(grunt));
+    service = options.service,
+    runFile = path.join(
+      options.runsFolder,
+      RunUtil.getRunFile(grunt));
 
   var tests = grunt.file.readJSON(runFile);
 

--- a/tests/run.spec.js
+++ b/tests/run.spec.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var RunUtil = require('../tasks/lib/run.js');
+
+describe('RunUtil', function() {
+  describe('#formatScriptOutput', function() {
+
+    var outputs = [{
+      key: 'key1',
+      label: 'Key 1',
+    }, {
+      key: 'key2',
+      label: 'Key 2'
+    }, {
+      key: 'z_key',
+      label: 'A key with Z at the start'
+    }, {
+      key: 'a_key',
+      label: 'A Key with A at the start'
+    }];
+
+    it('should work set outputs keys that are not defined', function() {
+
+      var data = {
+        key1: 'Some Key 1 Data',
+        z_key: 'Some more data'
+      };
+
+      var result = RunUtil.formatScriptOutput(outputs, data);
+      console.log(result);
+      expect(result).to.be.an('array').length(4);
+      expect(result[0].value).to.equal(data.key1);
+      expect(result[1].value).to.be.undefined;
+      expect(result[2].value).to.equal(data.z_key);
+      expect(result[3].value).to.undefined;
+    });
+
+    it('should preserve output field order', function() {
+      var data = {
+        key2: 'Some Key 2 Data',
+        key1: 'Some Key 1 Data',
+        a_key: 'More Data',
+        z_key: 'blah'
+      };
+
+      var result = RunUtil.formatScriptOutput(outputs, data);
+      expect(result[0].label).to.equal(outputs[0].label);
+      expect(result[1].label).to.equal(outputs[1].label);
+      expect(result[2].label).to.equal(outputs[2].label);
+      expect(result[3].label).to.equal(outputs[3].label);
+    });
+  });
+});


### PR DESCRIPTION
Fix for:
https://trello.com/c/5BveD6r7/560-sdk-all-outputs-defined-in-config-js-and-output-js-should-be-included-in-labelled-data-when-using-grunt-run
and
https://trello.com/c/Ux022j4N/561-sdk-when-outputing-labelled-fields-should-respect-order-in-configuration-as-per-ui

Maintain order of output keys as per the UI, and output all output keys whether or not a value has been set (just displays undefined).