### PR TITLE
fix ngrok postinstall.js error

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jshint-stylish": "^2.0.1",
     "load-grunt-tasks": "^3.2.0",
     "mocha": "^2.2.5",
-    "ngrok": "^0.1.99",
+    "ngrok": "^0.2.1",
     "open": "0.0.5",
     "passport": "^0.2.2",
     "passport-oauth2-refresh": "^0.4.0",


### PR DESCRIPTION
This was happening during `grunt init`