### PR TITLE
Call run script after receiving a webhook

### DIFF
--- a/tasks/lib/run.js
+++ b/tasks/lib/run.js
@@ -590,7 +590,7 @@ RunUtil.runWebhook = function(grunt, options, method, callback) {
 
     app.post('/', function(req, res) {
       res.status(200).send();
-      callback(null, req.body);
+      options.runner.run(method.slug, 'run', { input: req.body }, callback);
     });
     app.listen(options.webhookPort);
 


### PR DESCRIPTION
The run scripts were being ignored on webhooks.
The issue was because webhooks are delegated to "runWebhook", but this method executed the callback directly, without calling the run script first.