### PR TITLE
Add validation for fields with dependants

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -126,6 +126,10 @@ module.exports = function(chai, _) {
           new Assertion(input_option).to.have.property('value');
         });
       }
+      if(obj.dependants === true){
+        new Assertion(obj).to.have.property('type');
+        new Assertion(obj.type, 'Only \'select\' fields are allowed to have dependants').to.match(/^select$/);
+      }
     }
   });
 

--- a/tests/assertions.spec.js
+++ b/tests/assertions.spec.js
@@ -138,5 +138,41 @@ describe('Assertions', function() {
       }).to.throw('Must have valid auth type');
     });
 
+    it('should validate dependants', function() {
+      var input = [{
+        key: 'bob',
+        type: 'datetime',
+        label: 'Test',
+        dependants: true
+      }, {
+        key: 'rob',
+        type: 'select',
+        label: 'Test',
+        dependants: true,
+        input_options: []
+      }, {
+        key: 'ron',
+        type: 'datetime',
+        label: 'Test',
+        dependants: false
+      }, {
+        key: 'renne',
+        type: 'select',
+        label: 'Test',
+        dependants: false,
+        input_options: []
+      }];
+      expect(input).to.be.flowxo.input;
+      expect(function() {
+        expect(input[0]).to.be.flowxo.input.field;
+      }).to.throw('Only \'select\' fields are allowed to have dependants');
+      expect(function() {
+        expect(input).to.be.flowxo.input.fields;
+      }).to.throw('Only \'select\' fields are allowed to have dependants');
+      expect(input[1]).to.be.flowxo.input.field;
+      expect(input[2]).to.be.flowxo.input.field;
+      expect(input[3]).to.be.flowxo.input.field;
+    });
+
   });
 });


### PR DESCRIPTION
This PR should address issue #27.
I have extended the assertion for the field (at line 105: lib/chai.js) and added the test for it in (tests/assertions.spec.js).