### PR TITLE
Use cross-spawn instead of child_process

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "body-parser": "^1.13.3",
     "chai": "^3.2.0",
     "chalk": "^1.1.0",
+    "cross-spawn": "^2.0.0",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
     "grunt": "^0.4.5",

--- a/tasks/lib/init.js
+++ b/tasks/lib/init.js
@@ -5,7 +5,7 @@
 // as by nature, the SDK's dependencies may not
 // be available yet.
 
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn');
 
 var Init = {};
 


### PR DESCRIPTION
This should make `grunt init` work across multiple platforms.
Fixes issue #34.