### PR TITLE
Fix missing module bug on grunt init

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "Grzegorz Biziel"
   ],
   "dependencies": {
+    "cross-spawn": "^2.0.0",
     "flowxo-utils": "^1.1.0",
     "lodash": "^3.10.1",
     "validate.js": "^0.8.0",
@@ -27,7 +28,6 @@
     "body-parser": "^1.13.3",
     "chai": "^3.2.0",
     "chalk": "^1.1.0",
-    "cross-spawn": "^2.0.0",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
     "grunt": "^0.4.5",


### PR DESCRIPTION
Hello, I got this error running `grunt init`:

```
$ grunt init
Running "flowxo:init" (flowxo) task
Warning: Cannot find module 'cross-spawn' Use --force to continue.

Aborted due to warnings.
```

The problem is that `cross-spawn` was added as a devDependency, but it's needed for the task that is supposed to install the dev dependencies.
I made `cross-spawn` a regular dependency instead.