### PR TITLE
Add support for collections on the output fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "cross-spawn-async": "^2.1.6",
-    "flowxo-utils": "^1.1.1",
+    "flowxo-utils": "marian2js/flowxo-utils",
     "lodash": "^3.10.1",
     "validate.js": "^0.9.0",
     "winston": "^1.1.1"

--- a/tasks/lib/run.js
+++ b/tasks/lib/run.js
@@ -46,8 +46,29 @@ RunUtil.displayScriptData = function(grunt, data) {
  * array of arrays if the incoming data
  */
 RunUtil.formatScriptOutput = function(outputs, data) {
+  var getValueFromKeys = function(keys, data) {
+    return _.reduce(keys, function(prev, key) {
+      if(prev) {
+        return prev[key];
+      }
+      return null;
+    }, data);
+  };
+
   return FxoUtils.annotateOutputData(data, outputs, {
-    includeEmptyFields: true
+    includeEmptyFields: true,
+    arrayFormatter: function(keys, data) {
+      if(!data) {
+        return '';
+      }
+      return data
+        .map(function(item) {
+          return getValueFromKeys(keys, item)
+        })
+        .filter(function(item) {
+          return item;
+        });
+    }
   });
 };
 

--- a/tests/specs/tasks/run.spec.js
+++ b/tests/specs/tasks/run.spec.js
@@ -72,6 +72,27 @@ describe('RunUtil', function() {
       expect(result[0].value).to.equal(nested_data.top);
       expect(result[1].value).to.equal(nested_data.nested.value);
     });
+
+    it('should handle collections',function(){
+      var collection_outputs = [{
+        key: 'key_+_id',
+        label: 'Collection'
+      }];
+
+      var collection_data = {
+        key: [{
+          id: 1
+        }, {
+          id: 2
+        }, {
+          id: 3
+        }]
+      };
+
+      var result = RunUtil.formatScriptOutput(collection_outputs,collection_data);
+      expect(result).to.be.an('array').length(1);
+      expect(result[0].value).to.eql([ 1, 2, 3 ]);
+    });
   });
 
   describe('#convertDictInputToObject', function() {


### PR DESCRIPTION
Implemented the support for collections.
I updated the dependencies to make `flowxo-utils` point to my fork until [this PR](https://github.com/flowxo/flowxo-utils/pull/4) is merged.